### PR TITLE
Bail if there are no posts to filter

### DIFF
--- a/wp-pretty-filters.php
+++ b/wp-pretty-filters.php
@@ -16,6 +16,12 @@
  * @since 0.1.0
  */
 function _wp_pretty_filters() {
+	global $wp_query;
+	
+	if ( $wp_query->post_count < 1 ) {
+		// Bail if there are no posts to filter
+		return;
+	}
 
 	// Vars
 	$url = wp_pretty_filters_get_plugin_url();


### PR DESCRIPTION
If the post_count of the main query is < 1, don't add the pretty filters box because it will be empty.